### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/cloudformation/deployment.yaml
+++ b/cloudformation/deployment.yaml
@@ -447,7 +447,7 @@ Resources:
       Handler: index.handler
       Role: !GetAtt DeployFunctionRole.Arn
       Timeout: 300
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
 
   DeployArtifacts:
     Type: 'Custom::DeployUI'
@@ -513,7 +513,7 @@ Resources:
       Handler: index.handler
       Role: !GetAtt LambdaExecutionRole.Arn
       Timeout: 300
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Environment:
         Variables:
           GRAPHQL_ENDPOINT: !GetAtt GraphQLApi.GraphQLUrl
@@ -533,7 +533,7 @@ Resources:
       Handler: index.handler
       Role: !GetAtt LambdaExecutionRole.Arn
       Timeout: 300
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Environment:
         Variables:
           GRAPHQL_ENDPOINT: !GetAtt GraphQLApi.GraphQLUrl
@@ -553,7 +553,7 @@ Resources:
       Handler: index.handler
       Role: !GetAtt LambdaExecutionRole.Arn
       Timeout: 300
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Environment:
         Variables:
           GRAPHQL_ENDPOINT: !GetAtt GraphQLApi.GraphQLUrl
@@ -638,7 +638,7 @@ Resources:
       Handler: index.handler
       Role: !GetAtt AddPartitionFunctionRole.Arn
       Timeout: 900
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Environment:
         Variables:
           ATHENA_RESULT_BUCKET: !Ref PlayerLogsBucket

--- a/cloudformation/modules/fulldeploy.yaml
+++ b/cloudformation/modules/fulldeploy.yaml
@@ -447,7 +447,7 @@ Resources:
       Handler: index.handler
       Role: !GetAtt DeployFunctionRole.Arn
       Timeout: 300
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
 
   DeployArtifacts:
     Type: 'Custom::DeployUI'
@@ -513,7 +513,7 @@ Resources:
       Handler: index.handler
       Role: !GetAtt LambdaExecutionRole.Arn
       Timeout: 300
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Environment:
         Variables:
           GRAPHQL_ENDPOINT: !GetAtt GraphQLApi.GraphQLUrl
@@ -533,7 +533,7 @@ Resources:
       Handler: index.handler
       Role: !GetAtt LambdaExecutionRole.Arn
       Timeout: 300
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Environment:
         Variables:
           GRAPHQL_ENDPOINT: !GetAtt GraphQLApi.GraphQLUrl
@@ -553,7 +553,7 @@ Resources:
       Handler: index.handler
       Role: !GetAtt LambdaExecutionRole.Arn
       Timeout: 300
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Environment:
         Variables:
           GRAPHQL_ENDPOINT: !GetAtt GraphQLApi.GraphQLUrl
@@ -637,7 +637,7 @@ Resources:
       Handler: index.handler
       Role: !GetAtt AddPartitionFunctionRole.Arn
       Timeout: 900
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Environment:
         Variables:
           ATHENA_RESULT_BUCKET: !Ref PlayerLogsBucket

--- a/lambda-functions/activeuser-appsync-function/template.yaml
+++ b/lambda-functions/activeuser-appsync-function/template.yaml
@@ -5,7 +5,7 @@ Resources:
   AppSyncFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Handler: index.handler
       MemorySize: 128
       Timeout: 60

--- a/lambda-functions/recentvideoview-appsync-function/template.yaml
+++ b/lambda-functions/recentvideoview-appsync-function/template.yaml
@@ -5,7 +5,7 @@ Resources:
   AppSyncFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Handler: index.handler
       MemorySize: 128
       Timeout: 60

--- a/lambda-functions/totalvideoview-appsync-function/template.yaml
+++ b/lambda-functions/totalvideoview-appsync-function/template.yaml
@@ -5,7 +5,7 @@ Resources:
   AppSyncFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Handler: index.handler
       MemorySize: 128
       Timeout: 60


### PR DESCRIPTION
CloudFormation templates in aws-streaming-media-analytics have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.