### PR TITLE
Upgrade deprecated runtime nodejs6.10

### DIFF
--- a/lambda-functions/deploy-function/template.yaml
+++ b/lambda-functions/deploy-function/template.yaml
@@ -5,7 +5,7 @@ Resources:
   DeployFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       Handler: index.handler
       MemorySize: 128
       Timeout: 60


### PR DESCRIPTION
CloudFormation templates in aws-streaming-media-analytics have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs6.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.