### PR TITLE
Add s3 prefix parameter

### DIFF
--- a/Makefile.sample
+++ b/Makefile.sample
@@ -1,7 +1,9 @@
 .PHONY: all build package copycodeww copytemplateww syncvideos creates3 deletes3 deploy
 
-# The S3 bucket name prefix that will host the Cloudformation template and deployment artefacts
+# The S3 bucket name prefix that will host the Cloudformation template and deployment artifacts
 bucket = <your-bucket-name-prefix-here>
+# The prefix in the s3 bucket that all artifacts are stored under
+s3prefix = qos
 # The S3 bucket that hosts sample videos for the demo UI
 video_assets_bucket = aws-streaming-media-analytics-sourcecontent-us-east-1
 # The AWS regions (in standard format, e.g. us-east-1, us-west-2), you wish to build the code and deploy to. Separate by spaces.
@@ -65,36 +67,36 @@ deletes3:
 
 syncvideos:
 	@for region in $(regions);do \
-		aws s3 sync s3://$(video_assets_bucket)/output s3://$(bucket)-$$region/qos/sample-videos/ --acl public-read --profile $(profile);\
+		aws s3 sync s3://$(video_assets_bucket)/output s3://$(bucket)-$$region/$(s3prefix)/sample-videos/ --acl public-read --profile $(profile);\
 		mkdir -p assets/sample-videos;\
-		aws s3 ls --recursive s3://$(bucket)-$$region/qos/sample-videos/ --profile $(profile) | awk '{print $$4}' > assets/sample-videos/video-manifest.txt; \
-		aws s3 cp assets/sample-videos/video-manifest.txt s3://$(bucket)-$$region/qos/sample-videos/ --acl public-read --profile $(profile);\
+		aws s3 ls --recursive s3://$(bucket)-$$region/$(s3prefix)/sample-videos/ --profile $(profile) | awk '{print $$4}' > assets/sample-videos/video-manifest.txt; \
+		aws s3 cp assets/sample-videos/video-manifest.txt s3://$(bucket)-$$region/$(s3prefix)/sample-videos/ --acl public-read --profile $(profile);\
 	done
 
 copycodeww:
 	@for region in $(regions) ; do \
 	  echo $$region; echo $(bucket);\
-		aws s3 cp dist/deploy-function.zip s3://$(bucket)-$$region/qos/lambda-functions/ui-deployment/$(version)/ --acl public-read --profile $(profile); \
-		aws s3 cp dist/player-ui.zip s3://$(bucket)-$$region/qos/lambda-functions/ui-deployment/user-interfaces/$(version)/ --acl public-read --profile $(profile); \
-		aws s3 cp dist/cloudfront-logs-processor-function.zip s3://$(bucket)-$$region/qos/lambda-functions/cloudfront-logs-processor-function/$(version)/ --acl public-read --profile $(profile); \
-		aws s3 cp dist/fastly-logs-processor-function.zip s3://$(bucket)-$$region/qos/lambda-functions/fastly-logs-processor-function/$(version)/ --acl public-read --profile $(profile); \
-		aws s3 cp dist/recentvideoview-appsync-function.zip s3://$(bucket)-$$region/qos/lambda-functions/recentvideoview-appsync-function/$(version)/ --acl public-read --profile $(profile); \
-		aws s3 cp dist/totalvideoview-appsync-function.zip s3://$(bucket)-$$region/qos/lambda-functions/totalvideoview-appsync-function/$(version)/ --acl public-read --profile $(profile); \
-		aws s3 cp dist/activeuser-appsync-function.zip s3://$(bucket)-$$region/qos/lambda-functions/activeuser-appsync-function/$(version)/ --acl public-read --profile $(profile); \
-		aws s3 cp dist/add-partition-function.zip s3://$(bucket)-$$region/qos/lambda-functions/add-partition-function/$(version)/ --acl public-read --profile $(profile); \
-		aws s3 cp cloudformation/appsync_schema.graphql s3://$(bucket)-$$region/qos/lambda-functions/recentvideoview-appsync-function/$(version)/ --acl public-read --profile $(profile); \
-		aws s3 cp cloudformation/etl/player_log_job s3://$(bucket)-$$region/qos/etl/$(version)/ --acl public-read --profile $(profile); \
+		aws s3 cp dist/deploy-function.zip s3://$(bucket)-$$region/$(s3prefix)/lambda-functions/ui-deployment/$(version)/ --acl public-read --profile $(profile); \
+		aws s3 cp dist/player-ui.zip s3://$(bucket)-$$region/$(s3prefix)/lambda-functions/ui-deployment/user-interfaces/$(version)/ --acl public-read --profile $(profile); \
+		aws s3 cp dist/cloudfront-logs-processor-function.zip s3://$(bucket)-$$region/$(s3prefix)/lambda-functions/cloudfront-logs-processor-function/$(version)/ --acl public-read --profile $(profile); \
+		aws s3 cp dist/fastly-logs-processor-function.zip s3://$(bucket)-$$region/$(s3prefix)/lambda-functions/fastly-logs-processor-function/$(version)/ --acl public-read --profile $(profile); \
+		aws s3 cp dist/recentvideoview-appsync-function.zip s3://$(bucket)-$$region/$(s3prefix)/lambda-functions/recentvideoview-appsync-function/$(version)/ --acl public-read --profile $(profile); \
+		aws s3 cp dist/totalvideoview-appsync-function.zip s3://$(bucket)-$$region/$(s3prefix)/lambda-functions/totalvideoview-appsync-function/$(version)/ --acl public-read --profile $(profile); \
+		aws s3 cp dist/activeuser-appsync-function.zip s3://$(bucket)-$$region/$(s3prefix)/lambda-functions/activeuser-appsync-function/$(version)/ --acl public-read --profile $(profile); \
+		aws s3 cp dist/add-partition-function.zip s3://$(bucket)-$$region/$(s3prefix)/lambda-functions/add-partition-function/$(version)/ --acl public-read --profile $(profile); \
+		aws s3 cp cloudformation/appsync_schema.graphql s3://$(bucket)-$$region/$(s3prefix)/lambda-functions/recentvideoview-appsync-function/$(version)/ --acl public-read --profile $(profile); \
+		aws s3 cp cloudformation/etl/player_log_job s3://$(bucket)-$$region/$(s3prefix)/etl/$(version)/ --acl public-read --profile $(profile); \
 		done
 
 copytemplateww:
 		@for region in $(regions);do \
 		echo $$region;	echo $(bucket); \
-		sed -e "s/BUCKET_NAME/${bucket}/g" -e "s/VERSION/${version}/g" cloudformation/deployment_template.yaml > cloudformation/deployment.yaml; \
-		aws s3 cp cloudformation/deployment.yaml s3://$(bucket)-$$region/qos/cloudformation/$(version)/ --acl public-read --profile $(profile); \
+		sed -e "s/BUCKET_NAME/${bucket}/g" -e "s/VERSION/${version}/g" -e "s/S3_PREFIX/${s3prefix}/g" cloudformation/deployment_template.yaml > cloudformation/deployment.yaml; \
+		aws s3 cp cloudformation/deployment.yaml s3://$(bucket)-$$region/$(s3prefix)/cloudformation/$(version)/ --acl public-read --profile $(profile); \
 		done
 
 template:
-		sed -e "s/BUCKET_NAME/${bucket}/g" -e "s/VERSION/${version}/g" cloudformation/deployment_template.yaml > cloudformation/deployment.yaml
+		sed -e "s/BUCKET_NAME/${bucket}/g" -e "s/VERSION/${version}/g" -e "s/S3_PREFIX/${s3prefix}/g" cloudformation/deployment_template.yaml > cloudformation/deployment.yaml
 
 deploy:
 	aws cloudformation deploy --template-file cloudformation/deployment.yaml --stack-name $(stack_name)  --capabilities=CAPABILITY_NAMED_IAM --profile $(profile) --region us-west-2

--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ Pre-requisites:
 
 The build and deployment process for this project has been tested on both Mac and Linux using the vscode and Cloud9 IDEs respectively. 
 
-In Makefile:
+Build Configuration:
+
+Copy the Makefile.sample file to a file named Makefile. In the new file:
   - set `bucket` variable to reflect the S3 bucket name prefix which will be created within a deployment region. Note the region name will be appended to this prefix.
   - optionally, set the `s3prefix` variable to a prefix you wish to prepend to the path of all artifacts put into the S3 bucket(s).
   - set `regions` variable to reflect one or more AWS regions you want the code artifacts to be copied for CloudFormation deployment.

--- a/README.md
+++ b/README.md
@@ -82,13 +82,16 @@ This solution was originally developed for a workshop at AWS re:Invent 2018. An 
 Setup Instructions
 To build with Docker && make
 
-Pre-requisite:
+Pre-requisites:
 - Install `docker` for your environment as we will use a Docker container to build
 - Install AWS CLI
 - Install yarn
 
+The build and deployment process for this project has been tested on both Mac and Linux using the vscode and Cloud9 IDEs respectively. 
+
 In Makefile:
-  - set `bucket` variable to reflect the S3 bucket name prefix which will be created within a deployment region
+  - set `bucket` variable to reflect the S3 bucket name prefix which will be created within a deployment region. Note the region name will be appended to this prefix.
+  - optionally, set the `s3prefix` variable to a prefix you wish to prepend to the path of all artifacts put into the S3 bucket(s).
   - set `regions` variable to reflect one or more AWS regions you want the code artifacts to be copied for CloudFormation deployment.
   - set `stack_name` for the Stack Name to use in the deployment.
   - set `profile` to the AWS CLI profile which has necessary permissions to deploy and create all the resources required.

--- a/cloudformation/deployment_template.yaml
+++ b/cloudformation/deployment_template.yaml
@@ -6,13 +6,14 @@ Mappings:
     SourceCodeBucket:
       General:
         S3Bucket: 'BUCKET_NAME'
-        LambdaUIDeploymentCodePrefix: 'qos/lambda-functions/ui-deployment'
-        RecentVideoViewAppSyncCodePrefix: 'qos/lambda-functions/recentvideoview-appsync-function'
-        TotalVideoViewAppSyncCodePrefix: 'qos/lambda-functions/totalvideoview-appsync-function'
-        ActiveUserAppSyncCodePrefix: 'qos/lambda-functions/activeuser-appsync-function'
-        CloudfrontLogProcessorCodePrefix: 'qos/lambda-functions/cloudfront-logs-processor-function'
-        FastlyLogProcessorCodePrefix: 'qos/lambda-functions/fastly-logs-processor-function'
-        AddPartitionFunctionCodePrefix: 'qos/lambda-functions/add-partition-function'
+        S3Prefix: 'S3_PREFIX'
+        LambdaUIDeploymentCodePrefix: 'lambda-functions/ui-deployment'
+        RecentVideoViewAppSyncCodePrefix: 'lambda-functions/recentvideoview-appsync-function'
+        TotalVideoViewAppSyncCodePrefix: 'lambda-functions/totalvideoview-appsync-function'
+        ActiveUserAppSyncCodePrefix: 'lambda-functions/activeuser-appsync-function'
+        CloudfrontLogProcessorCodePrefix: 'lambda-functions/cloudfront-logs-processor-function'
+        FastlyLogProcessorCodePrefix: 'lambda-functions/fastly-logs-processor-function'
+        AddPartitionFunctionCodePrefix: 'lambda-functions/add-partition-function'
         UICodePrefix: 'user-interfaces'
         Version: 'VERSION'
 
@@ -375,7 +376,7 @@ Resources:
       Timeout: 300
       CodeUri:
         Bucket: !Join ["-", [!FindInMap [SourceCodeBucket, General, S3Bucket], !Ref "AWS::Region"]]
-        Key: !Join ["/",[!FindInMap [SourceCodeBucket, General, CloudfrontLogProcessorCodePrefix],!FindInMap [SourceCodeBucket, General, Version],"cloudfront-logs-processor-function.zip"]]
+        Key: !Join ["/",[!FindInMap [SourceCodeBucket, General, S3Prefix],!FindInMap [SourceCodeBucket, General, CloudfrontLogProcessorCodePrefix],!FindInMap [SourceCodeBucket, General, Version],"cloudfront-logs-processor-function.zip"]]
       Environment:
         Variables:
           KINESIS_FIREHOSE_STREAM: !Sub '${AWS::StackName}-cdnlogs-stream'
@@ -404,7 +405,7 @@ Resources:
       Timeout: 300
       CodeUri:
         Bucket: !Join ["-", [!FindInMap [SourceCodeBucket, General, S3Bucket], !Ref "AWS::Region"]]
-        Key: !Join ["/",[!FindInMap [SourceCodeBucket, General, FastlyLogProcessorCodePrefix],!FindInMap [SourceCodeBucket, General, Version],"fastly-logs-processor-function.zip"]]
+        Key: !Join ["/",[!FindInMap [SourceCodeBucket, General, S3Prefix],!FindInMap [SourceCodeBucket, General, FastlyLogProcessorCodePrefix],!FindInMap [SourceCodeBucket, General, Version],"fastly-logs-processor-function.zip"]]
       Environment:
         Variables:
           KINESIS_FIREHOSE_STREAM: !Sub '${AWS::StackName}-cdnlogs-stream'
@@ -453,13 +454,13 @@ Resources:
     Properties:
       Code:
         S3Bucket: !Join ["-", [!FindInMap ["SourceCodeBucket", "General", "S3Bucket"], !Ref "AWS::Region"]]
-        S3Key: !Join ["/", [!FindInMap ["SourceCodeBucket", "General", "LambdaUIDeploymentCodePrefix"], !FindInMap ["SourceCodeBucket", "General", "Version"], "deploy-function.zip"]]
+        S3Key: !Join ["/", [!FindInMap ["SourceCodeBucket", "General", "S3Prefix"], !FindInMap ["SourceCodeBucket", "General", "LambdaUIDeploymentCodePrefix"], !FindInMap ["SourceCodeBucket", "General", "Version"], "deploy-function.zip"]]
       MemorySize: 512
       Environment:
         Variables:
           SourceBucket: !Ref SourceBucket
           SourceFileBucket: !Join ["-", [!FindInMap ["SourceCodeBucket", "General", "S3Bucket"], !Ref "AWS::Region"]]
-          SourceUIFilePath: !Join ["/", [!FindInMap ["SourceCodeBucket", "General", "LambdaUIDeploymentCodePrefix"], !FindInMap ["SourceCodeBucket", "General", "UICodePrefix"], !FindInMap ["SourceCodeBucket", "General", "Version"], "player-ui.zip"]]
+          SourceUIFilePath: !Join ["/", [!FindInMap ["SourceCodeBucket", "General", "S3Prefix"], !FindInMap ["SourceCodeBucket", "General", "LambdaUIDeploymentCodePrefix"], !FindInMap ["SourceCodeBucket", "General", "UICodePrefix"], !FindInMap ["SourceCodeBucket", "General", "Version"], "player-ui.zip"]]
           UIPrefix: 'ui'
           VideoAssetsPrefix: 'sample-videos'
           SourceVideoAssetsPrefix: 'qos/sample-videos'
@@ -528,7 +529,7 @@ Resources:
     Properties:
       Code:
         S3Bucket: !Join ["-", [!FindInMap ["SourceCodeBucket", "General", "S3Bucket"], !Ref "AWS::Region"]]
-        S3Key: !Join ["/", [!FindInMap ["SourceCodeBucket", "General", "RecentVideoViewAppSyncCodePrefix"], !FindInMap ["SourceCodeBucket", "General", "Version"], "recentvideoview-appsync-function.zip"]]
+        S3Key: !Join ["/", [!FindInMap ["SourceCodeBucket", "General", "S3Prefix"], !FindInMap ["SourceCodeBucket", "General", "RecentVideoViewAppSyncCodePrefix"], !FindInMap ["SourceCodeBucket", "General", "Version"], "recentvideoview-appsync-function.zip"]]
       MemorySize: 512
       Handler: index.handler
       Role: !GetAtt LambdaExecutionRole.Arn
@@ -548,7 +549,7 @@ Resources:
     Properties:
       Code:
         S3Bucket: !Join ["-", [!FindInMap ["SourceCodeBucket", "General", "S3Bucket"], !Ref "AWS::Region"]]
-        S3Key: !Join ["/", [!FindInMap ["SourceCodeBucket", "General", "TotalVideoViewAppSyncCodePrefix"], !FindInMap ["SourceCodeBucket", "General", "Version"], "totalvideoview-appsync-function.zip"]]
+        S3Key: !Join ["/", [!FindInMap ["SourceCodeBucket", "General", "S3Prefix"], !FindInMap ["SourceCodeBucket", "General", "TotalVideoViewAppSyncCodePrefix"], !FindInMap ["SourceCodeBucket", "General", "Version"], "totalvideoview-appsync-function.zip"]]
       MemorySize: 512
       Handler: index.handler
       Role: !GetAtt LambdaExecutionRole.Arn
@@ -568,7 +569,7 @@ Resources:
     Properties:
       Code:
         S3Bucket: !Join ["-", [!FindInMap ["SourceCodeBucket", "General", "S3Bucket"], !Ref "AWS::Region"]]
-        S3Key: !Join ["/", [!FindInMap ["SourceCodeBucket", "General", "ActiveUserAppSyncCodePrefix"], !FindInMap ["SourceCodeBucket", "General", "Version"], "activeuser-appsync-function.zip"]]
+        S3Key: !Join ["/", [!FindInMap ["SourceCodeBucket", "General", "S3Prefix"], !FindInMap ["SourceCodeBucket", "General", "ActiveUserAppSyncCodePrefix"], !FindInMap ["SourceCodeBucket", "General", "Version"], "activeuser-appsync-function.zip"]]
       MemorySize: 512
       Handler: index.handler
       Role: !GetAtt LambdaExecutionRole.Arn
@@ -653,7 +654,7 @@ Resources:
     Properties:
       Code:
         S3Bucket: !Join ["-", [!FindInMap ["SourceCodeBucket", "General", "S3Bucket"], !Ref "AWS::Region"]]
-        S3Key: !Join ["/", [!FindInMap ["SourceCodeBucket", "General", "AddPartitionFunctionCodePrefix"], !FindInMap ["SourceCodeBucket", "General", "Version"], "add-partition-function.zip"]]
+        S3Key: !Join ["/", [!FindInMap ["SourceCodeBucket", "General", "S3Prefix"],!FindInMap ["SourceCodeBucket", "General", "AddPartitionFunctionCodePrefix"], !FindInMap ["SourceCodeBucket", "General", "Version"], "add-partition-function.zip"]]
       MemorySize: 512
       Handler: index.handler
       Role: !GetAtt AddPartitionFunctionRole.Arn
@@ -995,7 +996,7 @@ Resources:
     DependsOn: GraphQLApi
     Properties:
       ApiId: !GetAtt GraphQLApi.ApiId
-      DefinitionS3Location: !Join ["",["s3://",!Join ["/", [!Join ["-", [!FindInMap ["SourceCodeBucket", "General", "S3Bucket"], !Ref "AWS::Region"]],!Join ["/", [!FindInMap ["SourceCodeBucket", "General", "RecentVideoViewAppSyncCodePrefix"], !FindInMap ["SourceCodeBucket", "General", "Version"], "appsync_schema.graphql"]]]]]]
+      DefinitionS3Location: !Join ["",["s3://",!Join ["/", [!Join ["-", [!FindInMap ["SourceCodeBucket", "General", "S3Bucket"], !Ref "AWS::Region"]],!Join ["/", [!FindInMap ["SourceCodeBucket", "General", "S3Prefix"], !FindInMap ["SourceCodeBucket", "General", "RecentVideoViewAppSyncCodePrefix"], !FindInMap ["SourceCodeBucket", "General", "Version"], "appsync_schema.graphql"]]]]]]
 
   ApiKey:
     Type: AWS::AppSync::ApiKey


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This change adds a new s3prefix variable to the Makefile. This prefix is prepended to the path all code artifacts (cloudformation template, lambda functions, appsync graphql schema) are uploaded to S3 under. 

The default value of the prefix is set to 'qos' which remains consistent with previous versions. Customizing this value facilitates storing this code in a defined location in an S3 bucket (e.g. a bucket which is already structured and used for other build tasks). 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
