### PR TITLE
Update Lambda Runtimes to supported releases: Nodejs18.x python3.11

### DIFF
--- a/cloudformation/deployment_template.yaml
+++ b/cloudformation/deployment_template.yaml
@@ -371,7 +371,7 @@ Resources:
     Type: AWS::Serverless::Function
     DependsOn: LogProcessorFunctionRole
     Properties:
-      Runtime: python3.8
+      Runtime: python3.11
       Handler: prep-data.lambda_handler
       MemorySize: 128
       Timeout: 300
@@ -400,7 +400,7 @@ Resources:
     Condition: DeployFastlyIntegrationCondition
     DependsOn: LogProcessorFunctionRole
     Properties:
-      Runtime: python3.8
+      Runtime: python3.11
       Handler: prep-data.lambda_handler
       MemorySize: 128
       Timeout: 300
@@ -469,7 +469,7 @@ Resources:
       Handler: index.handler
       Role: !GetAtt DeployFunctionRole.Arn
       Timeout: 300
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
 
   DeployArtifacts:
     Type: 'Custom::DeployUI'
@@ -535,7 +535,7 @@ Resources:
       Handler: index.handler
       Role: !GetAtt LambdaExecutionRole.Arn
       Timeout: 300
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Environment:
         Variables:
           GRAPHQL_ENDPOINT: !GetAtt GraphQLApi.GraphQLUrl
@@ -555,7 +555,7 @@ Resources:
       Handler: index.handler
       Role: !GetAtt LambdaExecutionRole.Arn
       Timeout: 300
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Environment:
         Variables:
           GRAPHQL_ENDPOINT: !GetAtt GraphQLApi.GraphQLUrl
@@ -575,7 +575,7 @@ Resources:
       Handler: index.handler
       Role: !GetAtt LambdaExecutionRole.Arn
       Timeout: 300
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Environment:
         Variables:
           GRAPHQL_ENDPOINT: !GetAtt GraphQLApi.GraphQLUrl
@@ -660,7 +660,7 @@ Resources:
       Handler: index.handler
       Role: !GetAtt AddPartitionFunctionRole.Arn
       Timeout: 900
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Environment:
         Variables:
           ATHENA_RESULT_BUCKET: !Ref PlayerLogsBucket

--- a/lambda-functions/activeuser-appsync-function/package.json
+++ b/lambda-functions/activeuser-appsync-function/package.json
@@ -10,7 +10,8 @@
   "license": "ISC",
   "dependencies": {
     "es6-promise": "^4.2.8",
-    "isomorphic-fetch": "^3.0.0"
+    "isomorphic-fetch": "^3.0.0",
+    "aws-sdk": "^2.1456.0"
   },
   "devDependencies": {},
   "description": ""

--- a/lambda-functions/add-partition-function/package.json
+++ b/lambda-functions/add-partition-function/package.json
@@ -8,5 +8,8 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "description": ""
+  "description": "",
+  "dependencies": {
+    "aws-sdk": "^2.1456.0"
+  }
 }

--- a/lambda-functions/deploy-function/package.json
+++ b/lambda-functions/deploy-function/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "dependencies": {
     "adm-zip": "^0.4.16",
+    "aws-sdk": "^2.1456.0",
     "generate-password": "^1.6.1",
     "mime": "^2.5.2"
   },

--- a/lambda-functions/recentvideoview-appsync-function/package.json
+++ b/lambda-functions/recentvideoview-appsync-function/package.json
@@ -10,7 +10,8 @@
   "license": "ISC",
   "dependencies": {
     "es6-promise": "^4.2.8",
-    "isomorphic-fetch": "^3.0.0"
+    "isomorphic-fetch": "^3.0.0",
+    "aws-sdk": "^2.1456.0"
   },
   "devDependencies": {},
   "description": ""

--- a/lambda-functions/totalvideoview-appsync-function/package.json
+++ b/lambda-functions/totalvideoview-appsync-function/package.json
@@ -10,7 +10,8 @@
   "license": "ISC",
   "dependencies": {
     "es6-promise": "^4.2.8",
-    "isomorphic-fetch": "^3.0.0"
+    "isomorphic-fetch": "^3.0.0",
+    "aws-sdk": "^2.1456.0"
   },
   "devDependencies": {},
   "description": ""


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This Pull request updates the Lambda Runtimes to currently in-support releases: Nodejs18.x and Python3.11. The nodejs functions have also had aws-sdk v2 added to their package.json files explicitly. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
